### PR TITLE
🐛 fix(git): Add `docs/**` branch

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,6 +17,7 @@ labels:
 
   - label: 'type/docs'
     title: '^\s*.*?\sdocs(?:(.+))?!?:'
+    branch: '^docs/.*'
     files:
      - '**/*.md$'
      - '**/*.mdx$'


### PR DESCRIPTION
## Description

**What issue are you solving (or what feature are you adding) and how are you doing it?**

There seems to be a problem with auto-labeler labelling `type:docs`. So i am adding to check on the `docs/**` branch too and label that accordingly.