### PR TITLE
🐛 fix(git): Release `warp*` docker images too

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -25,7 +25,7 @@ on:
 
 env:
     REGISTRY: ghcr.io
-    IMAGE_NAME: netridotme/netris
+    IMAGE_NAME: netrisdotme/netris
     BASE_TAG_PREFIX: base
 
 jobs:

--- a/.github/workflows/warp-input.yml
+++ b/.github/workflows/warp-input.yml
@@ -23,7 +23,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: wanjohiryan/netris
+  IMAGE_NAME: netrisdotme/netris
   BASE_TAG_PREFIX: warp-input
 
 # concurrency:

--- a/.github/workflows/warp-input.yml
+++ b/.github/workflows/warp-input.yml
@@ -26,9 +26,9 @@ env:
   IMAGE_NAME: wanjohiryan/netris
   BASE_TAG_PREFIX: warp-input
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
+#   cancel-in-progress: true
   
 jobs:
     build-docker-pr:
@@ -73,7 +73,51 @@ jobs:
               with:
                 registry: ${{ env.REGISTRY }}
                 username: ${{ github.actor }}
-                password: ${{ secrets.GITHUB_TOKEN }}
+                password: ${{ secrets.GIT_MASTER_TOKEN }}
+            - 
+              name: Extract Container metadata
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ env.BASE_TAG_PREFIX }}
+                #
+                #tag on release, and a nightly build for 'dev'
+                tags: |
+                  type=raw,value=nightly,enable={{is_default_branch}}
+                  type=ref,event=tag
+                  type=semver,pattern={{version}}
+                  type=semver,pattern={{major}}.{{minor}}
+                  type=semver,pattern={{major}}
+            - 
+              name: Build Docker image
+              uses: docker/build-push-action@v5
+              with:
+                file: warp-input.Dockerfile
+                context: ./
+                push: true
+                tags: ${{ steps.meta.outputs.tags }}
+                labels: ${{ steps.meta.outputs.labels }}
+                
+    build-docker-release:
+        name: Build image on release
+        if: ${{ github.event_name == 'release' }}
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+        steps:
+            -
+              name: Checkout repo
+              uses: actions/checkout@v4
+              with:
+                submodules: recursive
+            - 
+              name: Log into registry ${{ env.REGISTRY }}
+              uses: docker/login-action@v3
+              with:
+                registry: ${{ env.REGISTRY }}
+                username: ${{ github.actor }}
+                password: ${{ secrets.GIT_MASTER_TOKEN }}
             - 
               name: Extract Container metadata
               id: meta
@@ -176,7 +220,7 @@ jobs:
           if: ${{ matrix.settings.host == 'windows-latest' }}
           uses: svenstaro/upload-release-action@2.9.0
           with: 
-            repo_token: ${{ secrets.GITHUB_TOKEN  }}
+            repo_token: ${{ secrets.GIT_MASTER_TOKEN  }}
             file: ./bin/input/warp-input.exe
             asset_name:  ${{ matrix.settings.asset_name }}
             tag: ${{ github.ref }}
@@ -185,7 +229,7 @@ jobs:
           if: ${{ matrix.settings.host != 'windows-latest' }}
           uses: svenstaro/upload-release-action@2.9.0
           with: 
-            repo_token: ${{ secrets.GITHUB_TOKEN  }}
+            repo_token: ${{ secrets.GIT_MASTER_TOKEN  }}
             file: ./bin/input/warp-input
             asset_name:  ${{ matrix.settings.asset_name }}
             tag: ${{ github.ref }}

--- a/.github/workflows/warp.yml
+++ b/.github/workflows/warp.yml
@@ -97,6 +97,50 @@ jobs:
                 tags: ${{ steps.meta.outputs.tags }}
                 labels: ${{ steps.meta.outputs.labels }}
                 
+    build-docker-release:
+        name: Build image on release
+        if: ${{ github.event_name == 'release' }}
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+        steps:
+            -
+              name: Checkout repo
+              uses: actions/checkout@v4
+              with:
+                submodules: recursive
+            - 
+              name: Log into registry ${{ env.REGISTRY }}
+              uses: docker/login-action@v3
+              with:
+                registry: ${{ env.REGISTRY }}
+                username: ${{ github.actor }}
+                password: ${{ secrets.GIT_MASTER_TOKEN }}
+            - 
+              name: Extract Container metadata
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ env.BASE_TAG_PREFIX }}
+                #
+                #tag on release, and a nightly build for 'dev'
+                tags: |
+                  type=raw,value=nightly,enable={{is_default_branch}}
+                  type=ref,event=tag
+                  type=semver,pattern={{version}}
+                  type=semver,pattern={{major}}.{{minor}}
+                  type=semver,pattern={{major}}
+            - 
+              name: Build Docker image
+              uses: docker/build-push-action@v5
+              with:
+                file: warp.Dockerfile
+                context: ./
+                push: true
+                tags: ${{ steps.meta.outputs.tags }}
+                labels: ${{ steps.meta.outputs.labels }}
+                
     build-warp-release:
       if: ${{ github.event_name == 'release' }}
       defaults:


### PR DESCRIPTION
## Description

**What issue are you solving (or what feature are you adding) and how are you doing it?**

`warp-input.yml` workflow was not getting invoked on push. So, I change the `Github Token` which has broader permissions.