### PR TITLE
🐛 fix(input): Append `input` to server's session ID for now

### DIFF
--- a/bin/input/src/main.rs
+++ b/bin/input/src/main.rs
@@ -61,7 +61,9 @@ async fn main() -> anyhow::Result<()> {
         .await
         .context("failed to create MoQ Transport session")?;
 
-    let (prod, sub) = serve::Track::new(config.namespace, config.track).produce();
+    let namespace = format!("{}input", config.namespace);
+
+    let (prod, sub) = serve::Track::new(namespace, config.track).produce();
 
     let input = input::Subscriber::new(sub);
 


### PR DESCRIPTION
## Description

**What issue are you solving (or what feature are you adding) and how are you doing it?**

I am having issues trying to append `input` to the session_id using bash. Most probably because supervisord is using the ENV variables already available in the container. So, here we append the `input` part inside the rust binary instead. This is much cleaner and it works.