### PR TITLE
🐛 fix(git): Build warp-input on push to main

### DIFF
--- a/.github/workflows/warp-input.yml
+++ b/.github/workflows/warp-input.yml
@@ -16,6 +16,7 @@ on:
         paths:
             - "warp-input.Dockerfile"
             - ".github/workflows/warp-input.yml"
+            - "bin/input/**"
         tags:
             - v*.*.*
     release:


### PR DESCRIPTION
## Description

**What issue are you solving (or what feature are you adding) and how are you doing it?**

There is a bug whereby `netris/warp-input` does not build and deploy a new nightly docker image when a pr is merged. This happens when there are changes in `bin/input/**` directory, and this is not the expected behaviour. So i added the directory back into the `warp-input.yml` workflow file.