### PR TITLE
✨ feat(server): Rename `/netris/proton` to `netris-proton`

### DIFF
--- a/.scripts/entrypoint.sh
+++ b/.scripts/entrypoint.sh
@@ -60,6 +60,9 @@ sudo ln -snf /dev/ptmx /dev/tty7
 # Start DBus without systemd
 sudo /etc/init.d/dbus start
 
+# Install Proton-GE for this user
+netris-proton -i
+
 # Install NVIDIA userspace driver components including X graphic libraries
 if ! command -v nvidia-xconfig &>/dev/null; then
   # Driver version is provided by the kernel through the container toolkit

--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -32,9 +32,8 @@ RUN mkdir -pm755 /etc/apt/keyrings && curl -fsSL -o /etc/apt/keyrings/winehq-arc
     && curl -fsSL -o /usr/share/bash-completion/completions/winetricks "https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks.bash-completion"
 
 #Install Proton
-COPY .scripts/proton /usr/bin/netris/
-RUN chmod +x /usr/bin/netris/proton \
-    && /usr/bin/netris/proton -i
+COPY .scripts/proton /usr/bin/netris-proton
+RUN chmod 755 /usr/bin/netris-proton
 
 ARG USERNAME=netris \
     PUID=1000 \


### PR DESCRIPTION
## Description

**What issue are you solving (or what feature are you adding) and how are you doing it?**

With help from @djpremier, rename `/usr/bin/netris/proton` as "the script cannot be found in bash `(eg.: $ proton -r /games/AlanWake.exe)` if it is in the subdirectory of /usr/bin, probably because it is found in a subdir inside `/usr/bin` "