### PR TITLE
🐛 fix(input): Retry when namespace doesn't exist

### DIFF
--- a/bin/input/Cargo.toml
+++ b/bin/input/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "netris-input"
+name = "warp-input"
 version = "0.0.1"
 edition = "2021"
 

--- a/bin/input/Cargo.toml
+++ b/bin/input/Cargo.toml
@@ -1,16 +1,18 @@
 [package]
-name = "warp-input"
+name = "netris-input"
 version = "0.0.1"
 edition = "2021"
 
 [dependencies]
 anyhow = "1.0.82"
+chrono = "0.4.38"
 clap = "4.5.4"
 enigo = "0.2.1"
 env_logger = "0.11.3"
 log = "0.4.21"
 moq-native = { git = "https://github.com/kixelated/moq-rs", version = "0.1.0" }
 moq-transport = { git = "https://github.com/kixelated/moq-rs", version = "0.5.0" }
+rand = "0.8.5"
 serde = { version="1.0.202" , features = ["derive"]}
 serde_json = "1.0.117"
 tokio = "1.37.0"

--- a/bin/input/src/cli.rs
+++ b/bin/input/src/cli.rs
@@ -5,7 +5,7 @@ use url::Url;
 #[derive(Parser, Clone, Debug)]
 pub struct Config {
 	/// Listen for UDP packets on the given address.
-	#[arg(long, default_value = "[::]:0")]
+	#[arg(long, default_value = "[::]:8080")]
 	pub bind: net::SocketAddr,
 
 	/// Connect to the given URL starting with https://

--- a/bin/input/src/input.rs
+++ b/bin/input/src/input.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use enigo::{
     Axis::Horizontal,
-    Coordinate::Abs,
+    Coordinate::Rel,
     Direction::{Press, Release},
     Enigo, Keyboard, Mouse, Settings,
 };
@@ -39,9 +39,7 @@ impl Subscriber {
 
     async fn recv_stream(mut track: StreamReader) -> anyhow::Result<()> {
         while let Some(mut group) = track.next().await? {
-            println!("received a stream");
             while let Some(object) = group.read_next().await? {
-                println!("received a stream 1");
                 let str = String::from_utf8_lossy(&object);
                 println!("{}", str);
             }
@@ -68,9 +66,10 @@ impl Subscriber {
                 let parsed: MessageObject = serde_json::from_str(&str)?;
                 match parsed.input_type.as_str() {
                     "mouse_move" => {
+                        //FIXME: Canvas height/width and screen width/height mismatch causes this to feel "accelerated"
                         if let (Some(x), Some(y)) = (parsed.delta_x, parsed.delta_y) {
                             // println!("Handling mouse_move with delta_x: {}, delta_y: {}", x, y);
-                            enigo.move_mouse(x, y, Abs).unwrap();
+                            enigo.move_mouse(x, y, Rel).unwrap();
                         }
                     }
                     "mouse_key_down" => {


### PR DESCRIPTION
## Description

**What issue are you solving (or what feature are you adding) and how are you doing it?**

`Warp-input` server errors out when the namespace or `session_id` has not yet been created on our relay. 
This is a problem, as we do not know when the user will start playing.  The idea is to have the bin/input run both a server and a client at the same time. Which can be used to then transmit bidirectional information.